### PR TITLE
Modularize the random generation

### DIFF
--- a/src/bin/beat.rs
+++ b/src/bin/beat.rs
@@ -1,33 +1,16 @@
 extern crate bytebeat;
-extern crate rand;
+
 use std::io::{Read, Write};
-use rand::Rng;
+
 
 fn main() {
-    // let mut code = String::new();
-    // let code = "t -1 <<".to_string();
-    // std::io::stdin().read_to_string(&mut code).unwrap();
-    // let code = bytebeat::parse_beat(&code).unwrap();
-    for j in 0..200 {
-        let length = rand::thread_rng().gen_range::<usize>(1, 16);
-        let code = bytebeat::random_beat(length);
-        for i in 0..1 {
-            let buf: Vec<_> = (i * 8000..(i + 1) * 8000)
-                .map(|t| bytebeat::eval_beat(&code, t as f64).unwrap() as u8)
-                .collect();
-            let mut is_silent = true;
-            for ele in &buf {
-                if *ele != 0 {
-                    is_silent = false;
-                    break;
-                }
-            }
-            if is_silent {
-                eprintln!("Skipping: {}", bytebeat::format_beat(&code))
-            } else {
-                std::io::stdout().write_all(&buf[..]).unwrap();
-            }
-        }
-        eprintln!("{}", bytebeat::format_beat(&code));
+    let mut code = String::new();
+    std::io::stdin().read_to_string(&mut code).unwrap();
+    let code = bytebeat::parse_beat(&code).unwrap();
+    for i in 0..60 {
+        let buf: Vec<_> = (i * 8000..(i + 1) * 8000)
+            .map(|t| bytebeat::eval_beat(&code, t as f64).unwrap() as u8)
+            .collect();
+        std::io::stdout().write_all(&buf[..]).unwrap();
     }
 }

--- a/src/bin/random.rs
+++ b/src/bin/random.rs
@@ -1,0 +1,31 @@
+extern crate bytebeat;
+extern crate rand;
+
+use std::io::{Read, Write};
+use rand::Rng;
+
+
+fn main() {
+    for j in 0..200 {
+        let length = rand::thread_rng().gen_range::<usize>(1, 16);
+        let code = bytebeat::random::random_beat(length);
+        let buf: Vec<_> = (0..8000)
+            .map(|t| bytebeat::eval_beat(&code, t as f64).unwrap() as u8)
+            .collect();
+
+        let mut is_silent = true;
+        for ele in &buf {
+            if *ele != 0 {
+                is_silent = false;
+                break;
+            }
+        }
+
+        if is_silent {
+            eprintln!("Skipping: {}", bytebeat::format_beat(&code))
+        } else {
+            std::io::stdout().write_all(&buf[..]).unwrap();
+        }
+        eprintln!("{}", bytebeat::format_beat(&code));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate rand;
 
-use rand::Rng;
+pub mod random;
+
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Cmd {
@@ -26,43 +27,6 @@ pub enum Cmd {
     DivF,
     ModF,
 }
-
-use Cmd::*;
-static OPERATORS: [Cmd; 15] = [Var, Var, Var, Var, Num(-1.0), Num(-1.0), Sub, Mul, Div, Mod, Shl, Shr, And, Orr, Xor];
-static OPERATORS2: [Cmd; 9] = [Sub, Mul, Div, Mod, Shl, Shr, And, Orr, Xor];
-static VALUES: [Cmd; 1] = [Var];
-pub fn random_beat(goal_length: usize) -> Vec<Cmd> {
-    let mut vec = Vec::new();
-    let mut num_args = 0;
-    while vec.len() < goal_length || num_args > 1 {
-        let mut random_cmd = *match num_args {
-            0 | 1 => {
-                rand::thread_rng().choose(&VALUES).unwrap()
-            },
-            _ => {
-                if vec.len() > goal_length {
-                    rand::thread_rng().choose(&OPERATORS2).unwrap()
-                } else {
-                    rand::thread_rng().choose(&OPERATORS).unwrap()
-                }
-            },
-        };
-
-        num_args += match random_cmd {
-            Var | Num(_) => 1,
-            _ => -1,
-        };
-
-        if let Num(_) = random_cmd {
-            let random_number = (rand::thread_rng().gen::<i32>() % 256).abs();
-            random_cmd = Num(random_number as f64);
-        }
-
-        vec.push(random_cmd);   
-    }
-    vec
-}
-
 
 pub fn eval_beat(cmds: &[Cmd], t: f64) -> Result<f64, ()> {
     use Cmd::*;

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,0 +1,53 @@
+use rand::{self, Rng};
+use super::Cmd;
+use Cmd::*;
+
+static OPERATORS: [Cmd; 15] = [
+    Var,
+    Var,
+    Var,
+    Var,
+    Num(-1.0),
+    Num(-1.0),
+    Sub,
+    Mul,
+    Div,
+    Mod,
+    Shl,
+    Shr,
+    And,
+    Orr,
+    Xor,
+];
+static OPERATORS2: [Cmd; 9] = [Sub, Mul, Div, Mod, Shl, Shr, And, Orr, Xor];
+static VALUES: [Cmd; 1] = [Var];
+
+pub fn random_beat(goal_length: usize) -> Vec<Cmd> {
+    let mut vec = Vec::new();
+    let mut num_args = 0;
+    while vec.len() < goal_length || num_args > 1 {
+        let mut random_cmd = *match num_args {
+            0 | 1 => rand::thread_rng().choose(&VALUES).unwrap(),
+            _ => {
+                if vec.len() > goal_length {
+                    rand::thread_rng().choose(&OPERATORS2).unwrap()
+                } else {
+                    rand::thread_rng().choose(&OPERATORS).unwrap()
+                }
+            }
+        };
+
+        num_args += match random_cmd {
+            Var | Num(_) => 1,
+            _ => -1,
+        };
+
+        if let Num(_) = random_cmd {
+            let random_number = (rand::thread_rng().gen::<i32>() % 256).abs();
+            random_cmd = Num(random_number as f64);
+        }
+
+        vec.push(random_cmd);
+    }
+    vec
+}


### PR DESCRIPTION
This moves the random generation into its own module, and moves the random
generator script into its own binary instead of replacing the bytebeat main.