### PR TITLE
Video encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+*.mp4

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -1,22 +1,36 @@
 extern crate bytebeat;
 
-use std::io::Write;
+use std::io::{Read, Write};
 
 #[derive(Copy, Clone)]
 struct Color([u8; 3]);
 
 
+const WIDTH: usize = 512;
+const HEIGHT: usize = 256;
+const SIZE: usize = WIDTH * HEIGHT * 2;
+const HZ: usize = 8000;
+const FPS: usize = 30;
+const FRAME_COUNT: usize = SIZE * FPS / HZ;
+
 
 fn main() {
-    const WIDTH: usize = 512;
-    const HEIGHT: usize = 256;
-    const SIZE: usize = WIDTH * HEIGHT;
-    const HZ: usize = 8000;
-    const FPS: usize = 30;
-    const FRAME_COUNT: usize = SIZE * FPS / HZ;
+    // Read in the expression
+    let code = {
+        println!("Enter a bytebeat command and then press Ctrl-D:");
+        let mut text = String::new();
+        std::io::stdin().read_to_string(&mut text).unwrap();
+        match bytebeat::parse_beat(&text) {
+            Ok(code) => code,
+            Err(_) => {
+                eprintln!("Error parsing bytebeat");
+                std::process::exit(1);
+            }
+        }
+    };
+    println!("Encoding...");
 
-    let code = "t t 12 >> t 8 >> | 63 t 4 >> & & *";
-    let code = bytebeat::parse_beat(code).unwrap();
+    // Generate the audio data
     let data = {
         let mut data = [0; SIZE];
         for i in 0..SIZE {
@@ -25,37 +39,30 @@ fn main() {
         data
     };
 
+    // Write the raw audio file as PCM
     {
         let mut audio_file = std::fs::File::create("audio").unwrap();
         audio_file.write_all(&data).unwrap();
     }
 
+    // Write the raw images as PPM
     {
         let video_file = std::fs::File::create("video").unwrap();
         let mut image = [Color([0, 0, 0]); WIDTH * HEIGHT];
         let mut out = std::io::BufWriter::new(video_file);
 
         for frame in 0..FRAME_COUNT {
-            for i in 0..SIZE {
-                let idx = (i % HEIGHT) * WIDTH + (i / HEIGHT);
-                image[idx] = Color([data[i], data[i] / 2, 0]);
-            }
-
-            let col = WIDTH * frame / FRAME_COUNT;
-            for row in 0..HEIGHT {
-                image[row * WIDTH + col] = Color([255, 255, 255]);
-            }
-            write_ppm(&mut out, &image, WIDTH, HEIGHT);
+            write_frame(&mut out, &mut image, &data, frame, Color([255, 100, 16]));
         }
     }
 
-    let _ = std::fs::remove_file("out.mp4");
+    // Use FFmpeg to convert the raw content into a video
     let fps = format!("{}", FPS);
     let hz = format!("{}", HZ);
     std::process::Command::new("ffmpeg")
         .args(&["-r", &fps, "-f", "image2pipe", "-i", "video"])
         .args(&["-f", "u8", "-ar", &hz, "-ac", "1", "-i", "audio"])
-        .args(&["-pix_fmt", "yuv420p", "out.mp4"])
+        .args(&["-pix_fmt", "yuv420p", "-y", "-s", "640x360", "out.mp4"])
         .spawn()
         .unwrap()
         .wait()
@@ -69,5 +76,51 @@ fn write_ppm<W: Write>(out: &mut W, buf: &[Color], width: usize, height: usize) 
     write!(out, "P6\n{} {}\n255\n", width, height).unwrap();
     for pix in buf {
         out.write(&pix.0[..]).unwrap();
+    }
+}
+
+fn write_frame<W: Write>(
+    out: &mut W,
+    image: &mut [Color],
+    data: &[u8],
+    frame: usize,
+    color: Color,
+) {
+    // Compute the offsets
+    let (col, off) = if frame < FRAME_COUNT / 4 {
+        (WIDTH * frame * 2 / FRAME_COUNT, 0)
+    } else if frame < 3 * FRAME_COUNT / 4 {
+        (
+            WIDTH / 2,
+            (frame - FRAME_COUNT / 4) * WIDTH * 2 / FRAME_COUNT,
+        )
+    } else {
+        (WIDTH * (frame - FRAME_COUNT / 2) * 2 / FRAME_COUNT, WIDTH)
+    };
+
+    // Draw the background
+    for i in 0..WIDTH * HEIGHT {
+        let idx = (i % HEIGHT) * WIDTH + (i / HEIGHT);
+        let x = data[i + off * HEIGHT];
+        image[idx] = color * x;
+    }
+
+    // Draw the cursor
+    for row in 0..HEIGHT {
+        image[row * WIDTH + col] = Color([255, 255, 255]);
+    }
+
+    // Output an image
+    write_ppm(out, &image, WIDTH, HEIGHT);
+}
+
+impl std::ops::Mul<u8> for Color {
+    type Output = Color;
+    fn mul(self, rhs: u8) -> Color {
+        let Color(lhs) = self;
+        let r = lhs[0] as u16 * rhs as u16;
+        let g = lhs[1] as u16 * rhs as u16;
+        let b = lhs[2] as u16 * rhs as u16;
+        Color([(r >> 8) as u8, (g >> 8) as u8, (b >> 8) as u8])
     }
 }

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -1,0 +1,73 @@
+extern crate bytebeat;
+
+use std::io::Write;
+
+#[derive(Copy, Clone)]
+struct Color([u8; 3]);
+
+
+
+fn main() {
+    const WIDTH: usize = 512;
+    const HEIGHT: usize = 256;
+    const SIZE: usize = WIDTH * HEIGHT;
+    const HZ: usize = 8000;
+    const FPS: usize = 30;
+    const FRAME_COUNT: usize = SIZE * FPS / HZ;
+
+    let code = "t t 12 >> t 8 >> | 63 t 4 >> & & *";
+    let code = bytebeat::parse_beat(code).unwrap();
+    let data = {
+        let mut data = [0; SIZE];
+        for i in 0..SIZE {
+            data[i] = bytebeat::eval_beat(&code, i as f64).unwrap() as u8;
+        }
+        data
+    };
+
+    {
+        let mut audio_file = std::fs::File::create("audio").unwrap();
+        audio_file.write_all(&data).unwrap();
+    }
+
+    {
+        let video_file = std::fs::File::create("video").unwrap();
+        let mut image = [Color([0, 0, 0]); WIDTH * HEIGHT];
+        let mut out = std::io::BufWriter::new(video_file);
+
+        for frame in 0..FRAME_COUNT {
+            for i in 0..SIZE {
+                let idx = (i % HEIGHT) * WIDTH + (i / HEIGHT);
+                image[idx] = Color([data[i], data[i] / 2, 0]);
+            }
+
+            let col = WIDTH * frame / FRAME_COUNT;
+            for row in 0..HEIGHT {
+                image[row * WIDTH + col] = Color([255, 255, 255]);
+            }
+            write_ppm(&mut out, &image, WIDTH, HEIGHT);
+        }
+    }
+
+    let _ = std::fs::remove_file("out.mp4");
+    let fps = format!("{}", FPS);
+    let hz = format!("{}", HZ);
+    std::process::Command::new("ffmpeg")
+        .args(&["-r", &fps, "-f", "image2pipe", "-i", "video"])
+        .args(&["-f", "u8", "-ar", &hz, "-ac", "1", "-i", "audio"])
+        .args(&["-pix_fmt", "yuv420p", "out.mp4"])
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
+
+    std::fs::remove_file("audio").unwrap();
+    std::fs::remove_file("video").unwrap();
+}
+
+fn write_ppm<W: Write>(out: &mut W, buf: &[Color], width: usize, height: usize) {
+    write!(out, "P6\n{} {}\n255\n", width, height).unwrap();
+    for pix in buf {
+        out.write(&pix.0[..]).unwrap();
+    }
+}


### PR DESCRIPTION
It turns out all the libraries for video encoding are hard to use, so…
```rust
std::process:Command::new("ffmpeg")
```
to the rescue!

This adds a new binary that generates `out.mp4` when you run it.

Closes #7 