### PR TITLE
Check well formedness ahead of time.

### DIFF
--- a/src/bin/beat.rs
+++ b/src/bin/beat.rs
@@ -5,10 +5,10 @@ fn main() {
     let mut code = String::new();
     std::io::stdin().read_to_string(&mut code).unwrap();
     let code = bytebeat::parse_beat(&code).unwrap();
-    let code = bytebeat::compile(code).unwrap();
+    let code = bytebeat::compile(code);
     for i in 0..60 {
         let buf: Vec<_> = (i * 8000..(i + 1) * 8000)
-            .map(|t| bytebeat::eval_beat(&code, t).unwrap().into())
+            .map(|t| bytebeat::eval_beat(&code, t).into())
             .collect();
         std::io::stdout().write_all(&buf[..]).unwrap();
     }

--- a/src/bin/beat.rs
+++ b/src/bin/beat.rs
@@ -5,7 +5,7 @@ fn main() {
     let mut code = String::new();
     std::io::stdin().read_to_string(&mut code).unwrap();
     let code = bytebeat::parse_beat(&code).unwrap();
-    let code = bytebeat::compile(code);
+    let code = bytebeat::compile(code).unwrap();
     for i in 0..60 {
         let buf: Vec<_> = (i * 8000..(i + 1) * 8000)
             .map(|t| bytebeat::eval_beat(&code, t).into())

--- a/src/bin/bot.rs
+++ b/src/bin/bot.rs
@@ -51,7 +51,7 @@ fn generate_beat() -> Program {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf).unwrap();
     let cmds = bytebeat::parse_beat(&buf).unwrap();
-    bytebeat::compile(cmds).unwrap()
+    bytebeat::compile(cmds)
 }
 
 fn encode_video(code: &Program) -> io::Result<Vec<u8>> {

--- a/src/bin/bot.rs
+++ b/src/bin/bot.rs
@@ -51,7 +51,7 @@ fn generate_beat() -> Program {
     let mut buf = String::new();
     std::io::stdin().read_to_string(&mut buf).unwrap();
     let cmds = bytebeat::parse_beat(&buf).unwrap();
-    bytebeat::compile(cmds)
+    bytebeat::compile(cmds).unwrap()
 }
 
 fn encode_video(code: &Program) -> io::Result<Vec<u8>> {

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -15,7 +15,7 @@ fn main() {
                 match bytebeat::compile(code) {
                     Ok(code) => code,
                     Err(compile_error) => {
-                        eprintln!("Error compiling bytebeat: {}", compile_error);
+                        eprintln!("{}", compile_error);
                         std::process::exit(1);
                     }
                 }

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -11,9 +11,17 @@ fn main() {
         let mut text = String::new();
         std::io::stdin().read_to_string(&mut text).unwrap();
         match bytebeat::parse_beat(&text) {
-            Ok(code) => bytebeat::compile(code).unwrap(),
-            Err(_) => {
-                eprintln!("Error parsing bytebeat");
+            Ok(code) => {
+                match bytebeat::compile(code) {
+                    Ok(code) => code,
+                    Err(compile_error) => {
+                        eprintln!("Error compiling bytebeat: {}", compile_error);
+                        std::process::exit(1);
+                    }
+                }
+            }
+            Err(parse_error) => {
+                eprintln!("Error parsing bytebeat: {}", parse_error);
                 std::process::exit(1);
             }
         }

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -11,15 +11,7 @@ fn main() {
         let mut text = String::new();
         std::io::stdin().read_to_string(&mut text).unwrap();
         match bytebeat::parse_beat(&text) {
-            Ok(code) => {
-                match bytebeat::compile(code) {
-                    Ok(code) => code,
-                    Err(_) => {
-                        eprintln!("Error compiling bytebeat");
-                        std::process::exit(1);
-                    }
-                }
-            }
+            Ok(code) => bytebeat::compile(code),
             Err(_) => {
                 eprintln!("Error parsing bytebeat");
                 std::process::exit(1);

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -11,7 +11,7 @@ fn main() {
         let mut text = String::new();
         std::io::stdin().read_to_string(&mut text).unwrap();
         match bytebeat::parse_beat(&text) {
-            Ok(code) => bytebeat::compile(code),
+            Ok(code) => bytebeat::compile(code).unwrap(),
             Err(_) => {
                 eprintln!("Error parsing bytebeat");
                 std::process::exit(1);

--- a/src/bin/util/mod.rs
+++ b/src/bin/util/mod.rs
@@ -17,7 +17,7 @@ pub fn generate_video(code: &Program, fname: &str) {
     let data = {
         let mut data = vec![0; size];
         for i in 0..size {
-            data[i] = bytebeat::eval_beat(&code, i as f64).unwrap().into();
+            data[i] = bytebeat::eval_beat(&code, i as f64).into();
         }
         data
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,20 +284,17 @@ pub fn eval_beat<T: Into<Val>>(program: &Program, t: T) -> Val {
                     if cond { a } else { b }
                 })
             }
+            Arr(0) => stack.push(0.into()),
             Arr(size) => {
                 let index: i64 = stack.pop().unwrap().into();
-                if size == 0 {
-                    stack.push(0.into());
-                } else {
-                    // We want to split off from the end, so we must subtract here.
-                    let split_index = stack.len() - size;
-                    let mut vec = stack.split_off(split_index);
-                    let size = size as i64;
-                    // Calculate the positive modulus (% gives remainder, which
-                    // is slightly different than mod for negative values)
-                    let index = ((index % size) + size) % size;
-                    stack.push(vec[index as usize]);
-                }
+                // We want to split off from the end, so we must subtract here.
+                let split_index = stack.len() - size;
+                let mut vec = stack.split_off(split_index);
+                let size = size as i64;
+                // Calculate the positive modulus (% gives remainder, which
+                // is slightly different than mod for negative values)
+                let index = ((index % size) + size) % size;
+                stack.push(vec[index as usize]);
             }
             // These have no runtime effect
             Fg(..) | Bg(..) | Khz(..) | Comment(..) => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub fn compile(cmds: Vec<Cmd>) -> Result<Program, CompileError> {
         }
     }
     // Validate the bytebeat by checking that the stack does not get popped when empty
-    let mut stack_size = 0 as i32;
+    let mut stack_size = 0 as isize;
     for (i, cmd) in cmds.iter().enumerate() {
         stack_size += match *cmd {
             Var | NumF(_) | NumI(_) => 1,
@@ -86,7 +86,7 @@ pub fn compile(cmds: Vec<Cmd>) -> Result<Program, CompileError> {
             // then pops x more values off the stack. Finally, it
             // pushes one value back onto the stack based on the index
             // Thus the net effect of Arr is to reduce the stack size by x.
-            Arr(x) => -(x as i32),
+            Arr(x) => -(x as isize),
             Cond => -2,
             // Split these into multiple branches to make rustfmt stop complaining
             Add | Sub | Mul | Div | Mod => -1,
@@ -113,7 +113,8 @@ impl std::fmt::Display for Program {
 #[derive(Debug)]
 pub struct CompileError {
     index: usize,
-    stack_size: i32,
+    stack_size: isize,
+}
 
 impl<'a> std::fmt::Display for CompileError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,16 @@ impl std::fmt::Display for Program {
 pub struct CompileError {
     index: usize,
     stack_size: i32,
+
+impl<'a> std::fmt::Display for CompileError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            fmt,
+            "Attempt to pop beyond stack size. index: {}, size of stack {}",
+            self.index,
+            self.stack_size
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -374,6 +384,19 @@ pub enum ParseError<'a> {
     BadBG(&'a str, usize),
     BadKhz(&'a str, usize),
     UnknownToken(&'a str, usize),
+}
+
+impl<'a> std::fmt::Display for ParseError<'a> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use ParseError::*;
+        match *self {
+            BadArr(token, index) => write!(fmt, "Bad Array op: {}, index: {}", token, index),
+            BadFG(token, index) => write!(fmt, "Bad Foreground Color: {}, index: {}", token, index),
+            BadBG(token, index) => write!(fmt, "Bad Background Color: {}, index: {}", token, index),
+            BadKhz(token, index) => write!(fmt, "Bad Sample Rate: {}, index: {}", token, index),
+            UnknownToken(token, index) => write!(fmt, "Unknown Token: {}, index: {}", token, index),
+        }
+    }
 }
 
 impl std::fmt::Display for Cmd {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,7 @@ mod tests {
         (
             name: $name:ident,
             code: [$($cmd:expr),* $(,)*],
+            index: $index:expr,
         ) => {
             mod $name {
                 use super::*;
@@ -494,6 +495,14 @@ mod tests {
                     let result = compile(cmd);
                     assert!(result.is_err());
                 }
+
+                #[test]
+                fn test_err_index() {
+                    use Cmd::*;
+                    let cmd = vec![$($cmd),*];
+                    let result = compile(cmd).err().unwrap();
+                    assert_eq!(result.index, $index);
+                }
             }
         }
     }
@@ -501,41 +510,49 @@ mod tests {
     test_invalid! {
         name: add_empty,
         code: [Add],
+        index: 0,
     }
 
     test_invalid! {
         name: add_small_stack,
         code: [Var, Add],
+        index: 1,
     }
 
     test_invalid! {
         name: cond_small_stack,
         code: [Var, Var, Cond],
+        index: 2,
     }
 
     test_invalid! {
         name: empty_arr_is_err,
         code: [Arr(0)],
+        index: 0,
     }
 
     test_invalid! {
         name: arr_stack_too_small,
         code: [Var, Arr(1)],
+        index: 1,
     }
 
     test_invalid! {
         name: arr_stack_too_small2,
         code: [NumI(1), NumI(2), NumI(3), Arr(3)],
+        index: 3,
     }
 
     test_invalid! {
         name: sin_empty,
         code: [Sin],
+        index: 0,
     }
 
     test_invalid! {
         name: should_not_dip_below_zero,
         code: [Var, Var, Var, Add, Add, Add, Var],
+        index: 5,
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl Program {
     }
 }
 
-pub fn compile(cmds: Vec<Cmd>) -> Result<Program, (Vec<Cmd>, CompileError)> {
+pub fn compile(cmds: Vec<Cmd>) -> Result<Program, CompileError> {
     use Cmd::*;
     let (mut bg, mut fg, mut khz) = (None, None, None);
     for cmd in &cmds {
@@ -96,14 +96,11 @@ pub fn compile(cmds: Vec<Cmd>) -> Result<Program, (Vec<Cmd>, CompileError)> {
         };
         if stack_size <= 0 {
             // Hand back the Vec<Cmd> since we probably shouldn't drop it.
-            return Err((
-                cmds.clone(),
-                CompileError {
-                    instruction: cmd.clone(),
-                    index: i,
-                    stack_size,
-                },
-            ));
+            return Err(CompileError {
+                cmds: cmds.clone(),
+                index: i,
+                stack_size,
+            });
         }
     }
     Ok(Program { cmds, bg, fg, khz })
@@ -117,7 +114,7 @@ impl std::fmt::Display for Program {
 
 #[derive(Debug)]
 pub struct CompileError {
-    instruction: Cmd,
+    cmds: Vec<Cmd>,
     index: usize,
     stack_size: isize,
 }
@@ -127,7 +124,7 @@ impl<'a> std::fmt::Display for CompileError {
         write!(
             fmt,
             "Attempt to pop beyond stack size. instruction: {} index: {}, size of stack {}",
-            self.instruction,
+            self.cmds[self.index],
             self.index,
             self.stack_size
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,42 +472,42 @@ mod tests {
         }
     }
 
-    test_invalid!{
+    test_invalid! {
         name: add_empty,
         code: [Add],
     }
 
-    test_invalid!{
+    test_invalid! {
         name: add_small_stack,
         code: [Var, Add],
     }
 
-    test_invalid!{
+    test_invalid! {
         name: cond_small_stack,
         code: [Var, Var, Cond],
     }
 
-    test_invalid!{
+    test_invalid! {
         name: empty_arr_is_err,
         code: [Arr(0)],
     }
 
-    test_invalid!{
+    test_invalid! {
         name: arr_stack_too_small,
         code: [Var, Arr(1)],
     }
 
-    test_invalid!{
+    test_invalid! {
         name: arr_stack_too_small2,
         code: [NumI(1), NumI(2), NumI(3), Arr(3)],
     }
 
-    test_invalid!{
+    test_invalid! {
         name: sin_empty,
         code: [Sin],
     }
 
-    test_invalid!{
+    test_invalid! {
         name: should_not_dip_below_zero,
         code: [Var, Var, Var, Add, Add, Add, Var],
     }
@@ -521,7 +521,7 @@ mod tests {
             Khz(8),
             Bg(Color([0, 0, 0])),
             Fg(Color([0, 0, 0])),
-            Comment("Hello".to_string()),
+            Comment("Hello".into()),
         ]);
         assert!(result.is_ok());
     }
@@ -537,7 +537,7 @@ mod tests {
                 use super::*;
 
                 #[test]
-                fn test_ok() {
+                fn test_compile() {
                     use Cmd::*;
                     let cmd = vec![$($cmd),*];
                     let result = Code::new(cmd);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,11 @@ impl Code {
                 // Thus the net effect of Arr is to reduce the stack size by x.
                 Arr(x) => -(x as i32),
                 Cond => -2,
-                _ => -1,
+                // Split these into multiple branches to make rustfmt stop complaining
+                Add | Sub | Mul | Div | Mod => -1,
+                Shl | Shr | And | Orr | Xor => -1,
+                Pow | AddF | SubF | MulF | DivF | ModF => -1,
+                Lt | Gt | Leq | Geq | Eq | Neq => -1,
             };
             if stack_size <= 0 {
                 return Err("Invalid bytebeat");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,7 @@ pub fn eval_beat<T: Into<Val>>(program: &Program, t: T) -> Val {
                 let index: i64 = stack.pop().unwrap().into();
                 // We want to split off from the end, so we must subtract here.
                 let split_index = stack.len() - size;
-                let mut vec = stack.split_off(split_index);
+                let vec = stack.split_off(split_index);
                 let size = size as i64;
                 // Calculate the positive modulus (% gives remainder, which
                 // is slightly different than mod for negative values)


### PR DESCRIPTION
This PR adds `Code`, which is a wrapper struct meant to make it not possible to create an invalid `Vec<Cmd>`. This simplifies the code for evaluating a bytebeat since we no longer need to check the stack's status every time we pop it.