### PR TITLE
Fix bot.rs to work with the egg-mode changes

### DIFF
--- a/src/bin/bot.rs
+++ b/src/bin/bot.rs
@@ -31,8 +31,7 @@ fn main() {
     println!("Rendered!");
 
     println!("Uploading video to twitter...");
-    let upload = media::UploadBuilder::new(&video_data[..], media::media_types::video_mp4())
-        .category(media::MediaCategory::Video);
+    let upload = media::UploadBuilder::new(&video_data[..], media::media_types::video_mp4());
     let media_handle = core.run(upload.call(&auth, &handle)).unwrap();
     println!("Uploaded!");
 


### PR DESCRIPTION
Egg-mode made the media_category part of the `UploadFuture` struct directly,
so we have to change accordingly.
(See: https://github.com/QuietMisdreavus/twitter-rs/commit/f840c07f62219388ed57d7bb2c12369a066ecdc4)

The bot does work, and has posted a tweet using this change (https://twitter.com/bytebeat_bot/status/937060661430976512)