### PR TITLE
Make empty programs invalid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,16 @@ pub struct CompileError {
     error_kind: ErrorKind,
 }
 
+impl CompileError {
+    pub fn vec(&self) -> &Vec<Cmd> {
+        &self.cmds
+    }
+
+    pub fn error_kind(&self) -> &ErrorKind {
+        &self.error_kind
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum ErrorKind {
     UnderflowedStack { index: usize, stack_size: isize },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,9 +80,9 @@ pub fn compile(cmds: Vec<Cmd>) -> Result<Program, CompileError> {
     }
     // Validate the bytebeat by checking that the stack does not get popped when empty
     let mut stack_size = 0 as isize;
-    let mut err_index = None;
+    let mut error_kind = None;
     for (index, cmd) in cmds.iter().enumerate() {
-        stack_size += match *cmd {
+        let change = match *cmd {
             Var | NumF(_) | NumI(_) | Hex(_) => 1,
             Fg(_) | Bg(_) | Khz(_) | Comment(_) => continue,
             // These all pop 1 value off the stack and push 1
@@ -100,18 +100,22 @@ pub fn compile(cmds: Vec<Cmd>) -> Result<Program, CompileError> {
             Pow | AddF | SubF | MulF | DivF | ModF => -1,
             Lt | Gt | Leq | Geq | Eq | Neq => -1,
         };
-        if stack_size <= 0 {
-            err_index = Some(index);
+        if stack_size + change <= 0 {
+            error_kind = Some(ErrorKind::UnderflowedStack { index, stack_size });
             break;
         }
+        // Do this after the if statement since we want to record the stack_size
+        // before applying the effect of the operator.
+        stack_size += change;
     }
-    match err_index {
+
+    if stack_size == 0 && error_kind.is_none() {
+        error_kind = Some(ErrorKind::EmptyProgram);
+    }
+
+    match error_kind {
         None => Ok(Program { cmds, bg, fg, khz }),
-        Some(index) => Err(CompileError {
-            cmds,
-            index,
-            stack_size,
-        }),
+        Some(error_kind) => Err(CompileError { cmds, error_kind }),
     }
 }
 
@@ -121,22 +125,33 @@ impl std::fmt::Display for Program {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct CompileError {
     cmds: Vec<Cmd>,
-    index: usize,
-    stack_size: isize,
+    error_kind: ErrorKind,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ErrorKind {
+    UnderflowedStack { index: usize, stack_size: isize },
+    EmptyProgram,
 }
 
 impl<'a> std::fmt::Display for CompileError {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            fmt,
-            "Attempt to pop beyond stack size. instruction: {} index: {}, size of stack {}",
-            self.cmds[self.index],
-            self.index,
-            self.stack_size
-        )
+        use ErrorKind::*;
+        match self.error_kind {
+            UnderflowedStack { index, stack_size } => {
+                write!(
+                    fmt,
+                    "Attempt to pop beyond stack size. instruction: {} index: {}, size of stack {}",
+                    self.cmds[index],
+                    index,
+                    stack_size
+                )
+            }
+            EmptyProgram => write!(fmt, "Program is empty: {:?}", self.cmds),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,11 @@ pub struct CompileError {
 }
 
 impl CompileError {
-    pub fn vec(&self) -> &Vec<Cmd> {
+    pub fn into_code(self) -> Vec<Cmd> {
+        self.cmds
+    }
+
+    pub fn as_code(&self) -> &[Cmd] {
         &self.cmds
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,8 +10,6 @@ macro_rules! test_invalid {
             use super::*;
             #[test]
             fn test_err_compile() {
-                // TODO: Find a better way to make the "empty" test
-                // not complain about unused imports?
                 #[allow(unused_imports)]
                 use Cmd::*;
                 let cmd = vec![$($cmd),*];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -4,12 +4,15 @@ macro_rules! test_invalid {
     (
         name: $name:ident,
         code: [$($cmd:expr),* $(,)*],
-        index: $index:expr,
+        err_kind: $err_kind:expr,
     ) => {
         mod $name {
             use super::*;
             #[test]
             fn test_err_compile() {
+                // TODO: Find a better way to make the "empty" test
+                // not complain about unused imports?
+                #[allow(unused_imports)]
                 use Cmd::*;
                 let cmd = vec![$($cmd),*];
                 let result = compile(cmd);
@@ -17,76 +20,76 @@ macro_rules! test_invalid {
             }
 
             #[test]
-            fn test_err_index() {
+            fn test_err_kind() {
+                #[allow(unused_imports)]
                 use Cmd::*;
+                use ErrorKind::*;
                 let cmd = vec![$($cmd),*];
                 let result = compile(cmd).err().unwrap();
-                assert_eq!(result.index, $index);
+                assert_eq!(result.error_kind, $err_kind);
             }
         }
     }
 }
 
 test_invalid! {
+    name: empty,
+    code: [],
+    err_kind: EmptyProgram,
+}
+
+test_invalid! {
     name: add_empty,
     code: [Add],
-    index: 0,
+    err_kind: UnderflowedStack { index: 0, stack_size: 0},
 }
 
 test_invalid! {
     name: add_small_stack,
     code: [Var, Add],
-    index: 1,
+    err_kind: UnderflowedStack { index: 1, stack_size: 1},
 }
 
 test_invalid! {
     name: cond_small_stack,
     code: [Var, Var, Cond],
-    index: 2,
+    err_kind: UnderflowedStack { index: 2, stack_size: 2},
 }
 
 test_invalid! {
     name: empty_arr_is_err,
     code: [Arr(0)],
-    index: 0,
+    err_kind: UnderflowedStack { index: 0, stack_size: 0},
 }
 
 test_invalid! {
     name: arr_stack_too_small,
     code: [Var, Arr(1)],
-    index: 1,
+    err_kind: UnderflowedStack { index: 1, stack_size: 1},
 }
 
 test_invalid! {
     name: arr_stack_too_small2,
     code: [NumI(1), NumI(2), NumI(3), Arr(3)],
-    index: 3,
+    err_kind: UnderflowedStack { index: 3, stack_size: 3},
 }
 
 test_invalid! {
     name: sin_empty,
     code: [Sin],
-    index: 0,
+    err_kind: UnderflowedStack { index: 0, stack_size: 0},
 }
 
 test_invalid! {
     name: should_not_dip_below_zero,
     code: [Var, Var, Var, Add, Add, Add, Var],
-    index: 5,
+    err_kind: UnderflowedStack { index: 5, stack_size: 1},
 }
 
-#[test]
-fn test_comments_ok() {
-    use Cmd::*;
-    // These should always be valid even on an empty stack
-    // !khz:8 !bg:000 !fg:000 #Hello
-    let result = compile(vec![
-        Khz(8),
-        Bg(Color([0, 0, 0])),
-        Fg(Color([0, 0, 0])),
-        Comment("Hello".into()),
-    ]);
-    assert!(result.is_ok());
+test_invalid! {
+    name: need_at_one_value_on_stack,
+    code: [Khz(8), Bg(Color([0, 0, 0])), Fg(Color([0, 0, 0])), Comment("Hello".into())],
+    err_kind: EmptyProgram,
 }
 
 macro_rules! test_beat {
@@ -458,6 +461,7 @@ fn test_metadata() {
         Khz(11),
         Fg(Color([1, 0, 0])),
         Bg(Color([0, 1, 1])),
+        NumI(0), // Required, empty programs are invalid.
     ];
     let prog = compile(code).unwrap();
     assert_eq!(prog.hz(), Some(11_000));


### PR DESCRIPTION
This PR also makes the "stack_size" portion of the UnderflowedStack error actually report the right thing.


A valid bytebeat needs at least one value on the stack in order
to actually have some sound. This commit invalidates both the empty program and programs consisting only of comments.

CompileError now features an `ErrorKind` field that describe which
type of error it is.

Resolves #63