### PR TITLE
Make really big arrays not panic bytebeat::compile()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub fn compile(cmds: Vec<Cmd>) -> Result<Program, CompileError> {
             // then pops x more values off the stack. Finally, it
             // pushes one value back onto the stack based on the index
             // Thus the net effect of Arr is to reduce the stack size by x.
-            Arr(x) => -(x as isize),
+            Arr(x) => -saturating_as_isize(x),
             Cond => -2,
             // Split these into multiple branches to make rustfmt stop complaining
             Add | Sub | Mul | Div | Mod => -1,
@@ -116,6 +116,14 @@ pub fn compile(cmds: Vec<Cmd>) -> Result<Program, CompileError> {
     match error_kind {
         None => Ok(Program { cmds, bg, fg, khz }),
         Some(error_kind) => Err(CompileError { cmds, error_kind }),
+    }
+}
+
+fn saturating_as_isize(num: usize) -> isize {
+    if num > isize::max_value() as usize {
+        isize::max_value()
+    } else {
+        num as isize
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -90,6 +90,18 @@ test_invalid! {
     err_kind: EmptyProgram,
 }
 
+#[test]
+fn test_really_big_arrays_invalid() {
+    // equal to i64::max_value() + 1
+    // a cast to i64 would make it equal to 9223372036854775807
+    let code = parse_beat("[9223372036854775808").unwrap();
+    assert!(compile(code).is_err());
+    // equal to i64::max_value() + 2\
+    // a cast i64 would make it equal to -9223372036854775808
+    let code = parse_beat("[9223372036854775809").unwrap();
+    assert!(compile(code).is_err());
+}
+
 macro_rules! test_beat {
     (
         name: $name:ident,


### PR DESCRIPTION
Really big arrays (ones whose size are larger than an isize) would cause
a panic due to isize overflows. This commit now forces these mega arrays
to saturate to `isize::max_value()` (this won't work for any arrays larger than a usize, but
I'm less worried about that since these arrays are still very very large).

Resolves #65