### PR TITLE
Update cargo-fmt install script for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ matrix:
     - rust: nightly
 
 before_script:
-  - export PATH="$PATH:$HOME/.cargo/bin"
-  - which rustfmt || cargo install rustfmt
+  - rustup component add rustfmt-preview
 script:
   - cargo fmt -- --write-mode=diff
   - cargo build --verbose

--- a/src/bin/beat.rs
+++ b/src/bin/beat.rs
@@ -2,7 +2,6 @@ extern crate bytebeat;
 
 use std::io::{Read, Write};
 
-
 fn main() {
     let mut code = String::new();
     std::io::stdin().read_to_string(&mut code).unwrap();

--- a/src/bin/bot.rs
+++ b/src/bin/bot.rs
@@ -8,12 +8,11 @@ use std::env;
 
 use bytebeat::Program;
 use dotenv::dotenv;
-use egg_mode::{media, Token, KeyPair};
+use egg_mode::{media, KeyPair, Token};
 use egg_mode::tweet::DraftTweet;
 use tokio_core::reactor::Core;
 
 mod util;
-
 
 fn main() {
     dotenv().ok();

--- a/src/bin/crashdecoder.rs
+++ b/src/bin/crashdecoder.rs
@@ -8,9 +8,9 @@ fn main() {
     let _ = std::io::stdin().read_to_end(&mut data);
 
     let time_kind = data[0];
-    let raw_num = (data[1] as u64) | (data[2] as u64) << 08 | (data[3] as u64) << 16 |
-        (data[4] as u64) << 24 | (data[5] as u64) << 32 |
-        (data[6] as u64) << 40 | (data[7] as u64) << 48 | (data[8] as u64) << 56;
+    let raw_num = (data[1] as u64) | (data[2] as u64) << 08 | (data[3] as u64) << 16
+        | (data[4] as u64) << 24 | (data[5] as u64) << 32 | (data[6] as u64) << 40
+        | (data[7] as u64) << 48 | (data[8] as u64) << 56;
     let time = if time_kind == 0 {
         Val::I(raw_num as i64)
     } else {

--- a/src/bin/encode.rs
+++ b/src/bin/encode.rs
@@ -11,15 +11,13 @@ fn main() {
         let mut text = String::new();
         std::io::stdin().read_to_string(&mut text).unwrap();
         match bytebeat::parse_beat(&text) {
-            Ok(code) => {
-                match bytebeat::compile(code) {
-                    Ok(code) => code,
-                    Err(compile_error) => {
-                        eprintln!("{}", compile_error);
-                        std::process::exit(1);
-                    }
+            Ok(code) => match bytebeat::compile(code) {
+                Ok(code) => code,
+                Err(compile_error) => {
+                    eprintln!("{}", compile_error);
+                    std::process::exit(1);
                 }
-            }
+            },
             Err(parse_error) => {
                 eprintln!("Error parsing bytebeat: {}", parse_error);
                 std::process::exit(1);

--- a/src/bin/util/mod.rs
+++ b/src/bin/util/mod.rs
@@ -1,7 +1,7 @@
 extern crate bytebeat;
 
 use bytebeat::Program;
-use bytebeat::encode::{EncoderConfig, Color};
+use bytebeat::encode::{Color, EncoderConfig};
 
 const WIDTH: usize = 640;
 const HEIGHT: usize = 360;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -2,7 +2,7 @@ use std::fs::{self, File};
 use std::process;
 use std::path::PathBuf;
 use std::ops::Mul;
-use std::io::{self, Write, BufWriter};
+use std::io::{self, BufWriter, Write};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Color(pub [u8; 3]);
@@ -92,12 +92,10 @@ impl EncoderConfig {
         let audio_path = self.audio_path.ok_or("audio path not set")?;
         let video_path = self.video_path.ok_or("video path not set")?;
 
-        let audio_file = BufWriter::new(File::create(&audio_path).map_err(
-            |_| "could not create audio file",
-        )?);
-        let video_file = BufWriter::new(File::create(&video_path).map_err(
-            |_| "could not create video file",
-        )?);
+        let audio_file =
+            BufWriter::new(File::create(&audio_path).map_err(|_| "could not create audio file")?);
+        let video_file =
+            BufWriter::new(File::create(&video_path).map_err(|_| "could not create video file")?);
 
         let (out_width, out_height) = self.out_dim.unwrap_or((self.width, self.height));
 

--- a/src/random.rs
+++ b/src/random.rs
@@ -27,7 +27,6 @@ pub fn random_t_multiply(goal_length: usize) -> Vec<Cmd> {
     compose(t_like, oscillator, Mul)
 }
 
-
 /// Return a random color
 pub fn random_color() -> Color {
     let r = rand::thread_rng().gen_range(0, 255);


### PR DESCRIPTION
Now that the rustfmt-preview component is shipping on stable, we can use that instead of depending on cargo install